### PR TITLE
Add the oldBranchName option and update all github functions to use it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,12 @@ class MasterToMain extends Command {
       required: false,
       default: 'main',
     }),
+    oldBranchName: flags.string({
+      char: 'o',
+      description: 'The name of the old branch to migrate from',
+      required: false,
+      default: 'master',
+    }),
   };
 
   async run(): Promise<void> {
@@ -57,6 +63,7 @@ class MasterToMain extends Command {
       repo,
       flags.accessToken,
       flags.newBranchName,
+      flags.oldBranchName,
       logger,
       flags.force
     );


### PR DESCRIPTION
## What does this change?
This change add a new CLI argument called oldBranchName (-o). This option can be used to specify the name of the branch to be migrated away from. The default value is master. This change makes the service more flexible and also allows the user to more easily revert the change if required (by setting the oldBranchName to main and the newBranchName to master).

## Images
![image](https://user-images.githubusercontent.com/30179286/92366731-717aa580-f0ed-11ea-9173-2154cbbbc760.png)

