### PR TITLE
Create issues for external config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ This tool requires two arguments.
 
 This tool can also be run with a number of options. The following table lists them all.
 
-| Option  | Short | Description                             | Default |
-| ------- | ----- | --------------------------------------- | ------- |
-| from    | -f    | The current name of the branch          | master  |
-| to      | -t    | The new name of the branch              | main    |
-| force   | -     | Disable any user prompts                | false   |
-| dry-run | -     | Log all of the steps but do not execute | false   |
-| verbose | -     | Output debug logs                       | false   |
+| Option   | Short | Description                                                                               | Default |
+| -------- | ----- | ----------------------------------------------------------------------------------------- | ------- |
+| from     | -f    | The current name of the branch                                                            | master  |
+| to       | -t    | The new name of the branch                                                                | main    |
+| force    | -     | Disable any user prompts                                                                  | false   |
+| dry-run  | -     | Log all of the steps but do not execute                                                   | false   |
+| verbose  | -     | Output debug logs                                                                         | false   |
+| guardian | -     | Run the guardian specific steps around build configuration. Disable using `--no-guardian` | true    |
 
 As well as this, the `--version` option can be used to display the current version install and the `--help` option can be used to display the help information.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ class MasterToMain extends Command {
     },
   ];
 
+  // TODO: Add not guardian option to disable riff-raff and team city checks
   static flags = {
     version: flags.version({ char: 'v', hidden: true }),
     help: flags.help({ char: 'h', hidden: true }),
@@ -35,6 +36,11 @@ class MasterToMain extends Command {
     verbose: flags.boolean({
       default: false,
       description: 'Output debug logs',
+    }),
+    guardian: flags.boolean({
+      default: true,
+      description: 'Output debug logs',
+      allowNo: true,
     }),
 
     from: flags.string({


### PR DESCRIPTION
## What does this change?
- Add a `guardian` flag which defaults to true. This can be used to disable guardian specific functions
- Add a check to see if there is a `riff-raff.yaml` file in the repository. If there is, open an issue on the repository
- Add a check to see if any files in the repository reference the old branch name. If any do, open a new issue on the repository.
- Open a new issue concerning all other build config which may need updating
