### PR TITLE
Work with private non-pro repos - Resolves #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A CLI tool to rename master branch to main for GitHub repos.
 - [Developing](#developing)
 
 # Quick Start
+
 master-to-main can be installed using either npm or yarn
 
 ```
@@ -18,7 +19,7 @@ npm install -g @guardian/master-to-main
 yarn global add @guardian/master-to-main
 ```
 
-It can then be run  as follows
+It can then be run as follows
 
 ```sh-session
 $ m2m [OWNER/REPO] [TOKEN]
@@ -87,7 +88,7 @@ The process carries out the following steps in order:
 1. Check if the repository exists (by getting the repo object)
 1. Check that the old branch name exists
 1. Check if the new branch name already exists
-1. Check if the user is an admin (by getting the branch protection for the master branch)
+1. Check if the user is an admin (by getting the username from the access token and then calling the get repository permissions for user endpoint)
 1. Get the number of open PRs and check with that user that they're happy to proceed
 1. Get the most recent commit sha from the master branch
 1. Create the new branch

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -456,6 +456,16 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
         );
         spinner.succeed();
         return;
+      } else if (
+        err.status === 403 &&
+        err.message ===
+          'Upgrade to GitHub Pro or make this repository public to enable this feature.'
+      ) {
+        this.logger.log(
+          'No branch proection (as not available on your tier) so skipping remaining steps'
+        );
+        spinner.succeed();
+        return;
       } else {
         spinner.fail();
         throw err;

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -8,6 +8,7 @@ import {
 import prompts from 'prompts';
 import Logger from './logger';
 import emoji from 'node-emoji';
+import { textChangeRangeIsUnchanged } from 'typescript';
 
 class GitHub {
   owner: string;
@@ -209,9 +210,7 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
   }
 
   async checkAdmin(): Promise<void> {
-    const msg = `Checking that you have the required permissions ${chalk.italic(
-      `(by checking if you can get the ${this.newBranchName} branch protection)`
-    )}`;
+    const msg = `Checking that you have the required permissions`;
 
     if (this.dryRun) {
       return this.logger.success(msg);
@@ -219,29 +218,26 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
 
     const spinner = this.logger.spin(msg);
     try {
-      await this.octokit.repos.getBranchProtection({
-        owner: this.owner,
-        repo: this.repo,
-        branch: this.oldBranchName,
-      });
-      spinner.succeed();
-    } catch (err) {
-      let error: Error;
-      if (
-        err.status === 401 ||
-        (err.status === 404 && err.message === 'Not Found')
-      ) {
-        error = new Error(
-          'You must be a repo admin to complete this migration'
-        );
-      } else if (err.status === 404 && err.message === 'Branch not protected') {
+      this.logger.log('Getting username from access token');
+      const user = await this.octokit.users.getAuthenticated();
+
+      this.logger.log('Getting repositoring permissions for user');
+      const permissions = await this.octokit.repos.getCollaboratorPermissionLevel(
+        {
+          owner: this.owner,
+          repo: this.repo,
+          username: user.data.login,
+        }
+      );
+
+      if (permissions.data.permission === 'admin') {
         spinner.succeed();
-        return;
       } else {
-        error = err;
+        throw new Error('You must be a repo admin to complete this migration');
       }
+    } catch (err) {
       spinner.fail();
-      throw error;
+      throw err;
     }
   }
 
@@ -545,13 +541,13 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
       if (!files.data.total_count) {
         this.logger.log('No riff-raff.yaml file found');
         spinner.succeed();
-        return
+        return;
       }
 
       if (!this.issues) {
         this.logger.log('riff-raff.yaml file found.');
-        spinner.succeed()
-        return 
+        spinner.succeed();
+        return;
       }
 
       this.logger.log('riff-raff.yaml file found. Opening an issue.');
@@ -591,17 +587,17 @@ A \`riff-raff.yaml\` file has been found in the repostiory meaning that you may 
       if (!files.data.total_count) {
         this.logger.log('No references found');
         spinner.succeed();
-        return
+        return;
       }
 
       if (!this.issues) {
         this.logger.log(
           `${files.data.total_count} ${
-          files.data.total_count === 1 ? 'file' : 'files'
+            files.data.total_count === 1 ? 'file' : 'files'
           } found.`
         );
-        spinner.succeed()
-        return
+        spinner.succeed();
+        return;
       }
 
       this.logger.log(
@@ -641,7 +637,7 @@ ${files.data.items
 
   async openOtherConfigurationIssue(): Promise<void> {
     if (!this.issues) {
-      return
+      return;
     }
 
     const msg = `Opening issue regarding other configuration`;


### PR DESCRIPTION
## What does this change?

- Update the step which checks user permissions to first get the user name of the authenticated user and then get the repo permissions for that user
- Update the branch protection step to return successfully if a 403 - Upgrade to pro error occurs

These changes are to resolve #6. Private repos on free plans cannot have branch protection and the resulting 403 error was causing the process to exit unexpectedly.