### PR TITLE
Resolve #9 - bug moving branch protection

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -356,7 +356,7 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
     const spinner = this.logger.spin(msg);
     try {
       this.logger.log(
-        `Geting the branch protection settings for ${this.oldBranchName}`
+        `Getting the branch protection settings for ${this.oldBranchName}`
       );
       const protection = await this.octokit.repos.getBranchProtection({
         owner: this.owner,
@@ -376,6 +376,7 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
       this.logger.log(
         `Creating the branch protection options object for ${this.newBranchName}`
       );
+
       const newProtection = {
         required_status_checks: p.required_status_checks
           ? {
@@ -420,7 +421,7 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
       };
 
       // This key needs to not be in the object at all if not required
-      if (!p.required_pull_request_reviews.dismissal_restrictions) {
+      if (!p.required_pull_request_reviews?.dismissal_restrictions) {
         delete newProtection.required_pull_request_reviews
           ?.dismissal_restrictions;
       }


### PR DESCRIPTION
## What does this change?
Add a `?` to the path to ensure we don't attempt to access the `dismissal_restrictions` key if `p.required_pull_request_reviews` is undefined

Resolves #9 