### PR TITLE
Update dry run mode to actually perform all the get requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ This tool can also be run with a number of options. The following table lists th
 | from     | -f    | The current name of the branch                                                            | master  |
 | to       | -t    | The new name of the branch                                                                | main    |
 | force    | -     | Disable any user prompts                                                                  | false   |
-| dry-run  | -     | Log all of the steps but do not execute                                                   | false   |
+| dry-run  | -     | Run without making changes for info. Disable using `-E`,`--execute` or `--no-dry-run`     | true    |
+| execute  | -E    | Shorthand to disable dry run mode                                                         | false   |
 | verbose  | -     | Output debug logs                                                                         | false   |
 | guardian | -     | Run the guardian specific steps around build configuration. Disable using `--no-guardian` | true    |
 | issues   | -     | Open issues for any further changes required. Disable using `--no-guardian`               | true    |
@@ -74,6 +75,10 @@ As well as this, the `--version` option can be used to display the current versi
 This tool is built on top of the [oclif](https://oclif.io/) library to provide CLI functionality.
 
 It interfaces with the GitHub API to carry out the necessary [steps](###steps) for the migration (more information below). It makes use of the [octokit](https://github.com/octokit/rest.js/) library.
+
+### Dry Run Mode
+
+The dry run mode can be used to see what would happen if the changes were made. The process will perform an GET requests and log all steps as if they were to be executed. This can be useful both to see how the process works without making changes and to run checks to reduce the change of encountering and error partway through the process.
 
 ### Auth
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ This tool can also be run with a number of options. The following table lists th
 | from     | -f    | The current name of the branch                                                            | master  |
 | to       | -t    | The new name of the branch                                                                | main    |
 | force    | -     | Disable any user prompts                                                                  | false   |
-| dry-run  | -     | Run without making changes for info. Disable using `-E`,`--execute` or `--no-dry-run`     | true    |
-| execute  | -E    | Shorthand to disable dry run mode                                                         | false   |
+| execute  | -x    | Execute the migration                                                                     | false   |
 | verbose  | -     | Output debug logs                                                                         | false   |
 | guardian | -     | Run the guardian specific steps around build configuration. Disable using `--no-guardian` | true    |
 | issues   | -     | Open issues for any further changes required. Disable using `--no-guardian`               | true    |
@@ -76,9 +75,9 @@ This tool is built on top of the [oclif](https://oclif.io/) library to provide C
 
 It interfaces with the GitHub API to carry out the necessary [steps](###steps) for the migration (more information below). It makes use of the [octokit](https://github.com/octokit/rest.js/) library.
 
-### Dry Run Mode
+### Exectuion
 
-The dry run mode can be used to see what would happen if the changes were made. The process will perform GET requests and log all steps as if they were to be executed. This can be useful both to see how the process works without making changes and to run checks to reduce the chance of encountering and error partway through the process.
+By default, the app runs in dry run mode. This will perform GET requests and log all steps as if they were to be executed. This can be useful both to see how the process works without making changes and to run checks to reduce the chance of encountering an error partway through the process. To execute the change, pass the `-x` or `--execute` flag.
 
 ### Auth
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ It interfaces with the GitHub API to carry out the necessary [steps](###steps) f
 
 ### Dry Run Mode
 
-The dry run mode can be used to see what would happen if the changes were made. The process will perform an GET requests and log all steps as if they were to be executed. This can be useful both to see how the process works without making changes and to run checks to reduce the change of encountering and error partway through the process.
+The dry run mode can be used to see what would happen if the changes were made. The process will perform GET requests and log all steps as if they were to be executed. This can be useful both to see how the process works without making changes and to run checks to reduce the chance of encountering and error partway through the process.
 
 ### Auth
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,13 @@ class MasterToMain extends Command {
       description: 'Disable any user prompts',
     }),
     'dry-run': flags.boolean({
-      default: false,
+      default: true,
       description: 'Log all of the steps but do not execute',
+      allowNo: true,
+    }),
+    execute: flags.boolean({
+      default: false,
+      description: 'Shorthand for --dry-run=false or --no-dry-run',
     }),
     verbose: flags.boolean({
       default: false,
@@ -38,12 +43,15 @@ class MasterToMain extends Command {
     }),
     guardian: flags.boolean({
       default: true,
-      description: 'Controls whether guardian specific steps are run. Use `--no-guardian` to disable',
+      description:
+        'Controls whether guardian specific steps are run. Use `--no-guardian` to disable',
       allowNo: true,
     }),
     issues: flags.boolean({
+      char: 'E',
       default: true,
-      description: 'Controls whether issues are created for further changes. Use `--no-issues` to disable',
+      description:
+        'Controls whether issues are created for further changes. Use `--no-issues` to disable',
       allowNo: true,
     }),
 
@@ -63,6 +71,11 @@ class MasterToMain extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = this.parse(MasterToMain);
+
+    // override the dry-run flag if someone has used the execute flag
+    if (flags.execute) {
+      flags['dry-run'] = false;
+    }
 
     const [owner, repo] = args.repository.split('/');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,10 @@ class MasterToMain extends Command {
       default: false,
       description: 'Disable any user prompts',
     }),
-    'dry-run': flags.boolean({
-      default: true,
-      description: 'Log all of the steps but do not execute',
-      allowNo: true,
-    }),
     execute: flags.boolean({
+      char: 'x',
       default: false,
-      description: 'Shorthand for --dry-run=false or --no-dry-run',
+      description: 'Execute the migration',
     }),
     verbose: flags.boolean({
       default: false,
@@ -48,7 +44,6 @@ class MasterToMain extends Command {
       allowNo: true,
     }),
     issues: flags.boolean({
-      char: 'E',
       default: true,
       description:
         'Controls whether issues are created for further changes. Use `--no-issues` to disable',
@@ -71,11 +66,6 @@ class MasterToMain extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = this.parse(MasterToMain);
-
-    // override the dry-run flag if someone has used the execute flag
-    if (flags.execute) {
-      flags['dry-run'] = false;
-    }
 
     const [owner, repo] = args.repository.split('/');
 


### PR DESCRIPTION
## What does this change?
This PR changes the dry run mode so that all the checks and GET requests are performed rather than just the message logged. This change has been made for two reasons:
1. It means that the dry run logging is more relevant to the actual case as it depends on the results of some GET requests
1. It surfaces any errors that are encountered performing the checks and GET requests without performing the updates and leaving the repository in a half migrated state

The dry run mode has also been made the default. An extra argument has been added so that rather than having to use `--no-dry-run` or `--dry-run=false` the `-E` or `--execute` flags can be passed instead.

The documentation and some log lines have been updated to reflect the changes made.

