### PR TITLE
Fixes #18 - Make the list of files that refer to the old branch a checklist

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -614,7 +614,7 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
 
   ${files.data.items
     .map((item) => {
-      return `- [${item.path}](${item.repository.html_url}/blob/${this.newBranchName}/${item.path})`;
+      return `- [ ] [${item.path}](${item.repository.html_url}/blob/${this.newBranchName}/${item.path})`;
     })
     .join('\n')}
           `,


### PR DESCRIPTION
## What does this change?

This PR fixes #18. It updates the issue which is created if any files contain a reference to the old branch name, making it a checklist instead of an unordered list. 

[Before](https://github.com/guardian/master-to-main-demo/issues/41)
[After](https://github.com/guardian/master-to-main-demo/issues/44)

## How to test
Run the master to main script on a repo which contains files referencing `master`. Check that the issue created contains a checklist.

## How can we measure success?
New issues created contain a checklist of files which reference the old branch name.