### PR TITLE
Amend search for `riff-raff.yaml` file to include all directories

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -527,7 +527,7 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
     const spinner = this.logger.spin(msg);
     try {
       const files = await this.octokit.search.code({
-        q: `repo:${this.owner}/${this.repo}+filename:riff-raff.yaml`,
+        q: `repo:${this.owner}/${this.repo}+filename:*/riff-raff.yaml`,
       });
 
       if (!files.data.total_count) {


### PR DESCRIPTION
## What does this change?

As part of the `master-to-main` process, we check the repository for a `riff-raff.yaml` file and open an issue if one is present. Currently this search only looks at the top level of the repository. This PR updates the search so that if a `riff-raff.yaml` is present in any directory, an issue will be opened. This PR fixes #15 

## How to test

1. Create a demo repository with a `riff-raff.yaml` file within a directory.
1. Run the current `master-to-main` tool and see that you don't get an issue for updating RiffRaff configuration.
1. Run this branch and see that now you do get an issue.

## How can we measure success?

An issue is opened for repositories that contain a `riff-raff.yaml` file not at the top level. 