### PR TITLE
Add cautions around GitHub token security and lifespan

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ By default, the app runs in dry run mode. This will perform GET requests and log
 
 Authentication and authorisation is handled using GitHub Personal Access Tokens (PATs). You will need to provide this using the `-t` option when running the tool.
 
+**N.B. Treat your tokens like passwords and keep them secret. Consider using environment variables to store tokens during use and remove any tokens that are not in use.**
+
 You can create a token from the `Developer settings` tab within GitHub settings. For public repos, the `public_repo` scope will suffice. For private repos, the `repo` scope is needed.
+
+It is recommended that a new token is created specifically for the purpose of running this tool, so that the token can be removed from your account immediately after the process is complete.
 
 ### Steps
 


### PR DESCRIPTION
## What does this change?

Adding a couple more notes to the README to encourage good practices regarding permanent API credentials.

GitHub does delete tokens after a year of inactivity. However, that is probably 360 days longer than necessary.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Another chance to encourage some credential best practices.

Users of this tool will be encouraged to run it with a short-lived credential that can be immediately deleted/revoked in the event of it being accidentally shared or leaked. 🤞 

GitHub API tokens should only exist while they are being used.

## Have we considered potential risks?

Adding a couple of sentences does mean a slightly longer README and it is possible not everyone will read the precautions.
It is only a couple more lines and at least we can try to make users more aware the security and lifespan of their access tokens.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="759" alt="Screenshot 2020-10-26 at 12 28 37" src="https://user-images.githubusercontent.com/8607683/97172331-cbf7c000-1786-11eb-86be-c345d0a2b5e7.png">

