### PR TITLE
Remove the rouge `s` from the editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,6 @@ insert_final_newline = true
 
 [*.ts]
 quote_type = single
-s
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
## What does this change?

This PR removes the random `s` from the `.editorconfig` file that shouldn't have been there in the first place. 🤭 