### PR TITLE
Update `Other config changes` issue

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -665,9 +665,9 @@ For each deployment, you will need to complete the following steps:
           ${
             this.guardian
               ? `
-  - TeamCity
-  - Change snyk github integration(s) - it uses the default branch, but you will need to delete and reimport the project+file as this is the only way to refresh the default branch at present.
-  - Any other externally configured analysis tooling your team is using e.g. travis CI
+  - [ ] TeamCity - See the required steps in the [migrating.md](https://github.com/guardian/master-to-main/blob/main/migrating.md#update-ci-typically-teamcity) document
+  - [ ] Change snyk github integration(s) - it uses the default branch, but you will need to delete and reimport the project+file as this is the only way to refresh the default branch at present.
+  - [ ] Any other externally configured analysis tooling your team is using e.g. travis CI
           `
               : ''
           }


### PR DESCRIPTION
## What does this change?

This PR updates the `Other Config Changes` issue opened by the `master-to-main` process - fixing #17. It:

* Adds a link to the team city steps in the `migrating.md` doc
* Makes the required steps a checklist

[Before](https://github.com/guardian/master-to-main-demo/issues/62)
[After](https://github.com/guardian/master-to-main-demo/issues/65)