### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# See the documentation for all configuration options https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What does this change?

This PR adds dependabot to check for updates to both npm modules and GitHub actions. 

## How to test

Wait and see if dependabot starts opening PRs

## How can we measure success?

Dependabot opens PRs to update packages