### PR TITLE
fix: remove ambiguous extra point in RiffRaff issue

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -316,7 +316,6 @@ $ git branch -m ${this.oldBranchName} ${this.newBranchName}
 
 For each deployment, you will need to complete the following steps:
 
-1. Change riffraff CD/branch protection to the new branch regex.
 1. Fix continuous deployments: https://riffraff.gutools.co.uk/deployment/continuous
 1. Ensure blocked deployments are still blocked: https://riffraff.gutools.co.uk/deployment/restrictions
           `,


### PR DESCRIPTION
## What does this change?

This PR updates the issue created which prompts the user to update to remove the first point which is the same, but more confusing, than the second point.

before
```
1. Change riffraff CD/branch protection to the new branch regex.
2. Fix continuous deployments: https://riffraff.gutools.co.uk/deployment/continuous
3. Ensure blocked deployments are still blocked: https://riffraff.gutools.co.uk/deployment/restrictions
```
after
```
1. Fix continuous deployments: https://riffraff.gutools.co.uk/deployment/continuous
2. Ensure blocked deployments are still blocked: https://riffraff.gutools.co.uk/deployment/restrictions
```

## How to test

Run the process and see that the issue created follows the new format

## How can we measure success?

The issue created is more clear about the required steps
