### PR TITLE
chore: enable validateSingleCommit setting

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,5 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.0
+        with:
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          # https://github.com/amannn/action-semantic-pull-request
+          validateSingleCommit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

We use the [amannn/action-semantic-pull-request action](https://github.com/amannn/action-semantic-pull-request) to validate that pull request titles conform to the angular commit convention. This actions provides an additional option to validate the commit message if a PR only has one commit as this commit message will be the suggested one when squashing and merging. This PR turns that setting on.

## How to test

Open a single commit PR with an invalid commit and see the check fail.

## How can we measure success?

Reduced risk of incorrect semantic release behaviour.