### PR TITLE
chore: move dependency install to workflow from scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,20 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@main
+      - uses: bahmutov/npm-install@v1
       - run: ./script/build
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@main
+      - uses: bahmutov/npm-install@v1
       - run: ./script/lint
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@main
+      - uses: bahmutov/npm-install@v1
       - run: ./script/test

--- a/script/build
+++ b/script/build
@@ -2,10 +2,4 @@
 
 set -e
 
-# only install dependencies when running in CI (currently GitHub Actions)
-# see https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
-if [ $CI ] ; then
-  yarn --frozen-lockfile
-fi
-
 yarn build

--- a/script/lint
+++ b/script/lint
@@ -2,10 +2,4 @@
 
 set -e
 
-# only install dependencies when running in CI (currently GitHub Actions)
-# see https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
-if [ $CI ] ; then
-  yarn --frozen-lockfile
-fi
-
 yarn lint

--- a/script/test
+++ b/script/test
@@ -2,10 +2,4 @@
 
 set -e
 
-# only install dependencies when running in CI (currently GitHub Actions)
-# see https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
-if [ $CI ] ; then
-  yarn --frozen-lockfile
-fi
-
 yarn test


### PR DESCRIPTION
## What does this change?

This PR moves the step which installs dependencies from the individual scripts into the workflows file. It's uses the [bahmutov/npm-install](https://github.com/bahmutov/npm-install) action so that we also get caching. It also brings a marginal reduction in LoC and complexity as it's a one-liner in the workflow file. The scripts are left so that the repository still follows the scripts pattern.

## How to test

See the CI checks run on this PR.

## How can we measure success?

Simpler configuration and quicker CI checks.

## Have we considered potential risks?

n/a