### PR TITLE
chore: Run Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      # This repository is never used in a PROD environment and we can afford to run old versions for a short time. Run Dependabot once a month to reduce the frequency of PRs
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "


### PR DESCRIPTION
As this repository is only used locally and never in PROD, we can afford to run old versions of dependencies for a short time. Update Dependabot's configuration to run monthly to reduce the frequency of PRs by a quarter and thus require less commitment from the team.