### PR TITLE
chore: Use built in caching from setup-node action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,20 +7,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+      - uses: guardian/actions-setup-node@v2.4.0
+        with:
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
       - run: ./script/build
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+      - uses: guardian/actions-setup-node@v2.4.0
+        with:
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
       - run: ./script/lint
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+      - uses: guardian/actions-setup-node@v2.4.0
+        with:
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
       - run: ./script/test


### PR DESCRIPTION
## What does this change?

This change updates the _ci_ workflow to use caching implemented by [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) now that it's available. It also swaps out [bahmutov/npm-install](https://github.com/bahmutov/npm-install) for `yarn install --frozen-lockfile` as we no longer need the caching implemented by that action.