### PR TITLE
chore: bump actions-setup-node version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: "yarn"
       - run: yarn install --frozen-lockfile
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: "yarn"
       - run: yarn install --frozen-lockfile
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: "yarn"
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## What does this change?

Bump the version of [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node)