### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/developer-experience
+* @guardian/devx-operations


### PR DESCRIPTION
## What does this change?

updates codeowners to @guardian/devx-operations so that not all devex teams are notified about this repo

