### PR TITLE
ci: Add Workflow to combine Dependabot PRs

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,0 +1,20 @@
+name: Combine PRs
+
+on:
+  schedule:
+    - cron: '0 1 * * 3' # Wednesday at 01:00
+  workflow_dispatch: # allows you to manually trigger the workflow
+
+permissions:
+  contents: write # to create a new branch and merge other branches together
+  pull-requests: write # to create a new PR with the combined changes
+  checks: read # to check if CI is passing or not before combining PRs
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/combine-prs@v3.1.1
+        with:
+          pr_title: 'chore(deps): Combine PRs'
+          labels: 'dependencies'


### PR DESCRIPTION
## What does this change?
Attempt to bring order to Dependabot PRs by using https://github.com/marketplace/actions/combine-prs
to batch them together.

This would mean we have one PR to review, rather than multiple.

The raised PR will [not trigger a build](https://github.com/marketplace/actions/combine-prs#ci-and-actions-token-). I'll address this in a follow-up PR.